### PR TITLE
Add more docs for installing

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "deps/tinycc"]
 	path = deps/tinycc
-	url = git@github.com:promovicz/tinycc.git
+	url = https://github.com/promovicz/tinycc.git
 	branch = promovicz/mob
 [submodule "deps/bdwgc"]
 	path = deps/bdwgc

--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -4,7 +4,7 @@ ARG BASE="debian:stable"
 FROM ${BASE}
 
 # configuration
-ENV CPLR_DEPENDS="build-essential autoconf automake cmake libreadline-dev libtool make"
+ENV CPLR_DEPENDS="build-essential autoconf automake cmake libreadline-dev libtool make git"
 ENV CPLR_CONFIG="-DCMAKE_INSTALL_PREFIX=/usr/local -DCMAKE_BUILD_TYPE=RelWithDebInfo"
 
 # install dependencies
@@ -16,6 +16,9 @@ RUN apt-get update \
 # copy, build, install
 WORKDIR /build
 COPY ./ /build/src
+RUN cd /build/src \
+ && git submodule init \
+ && git submodule update
 RUN mkdir -p build \
  && cd build \
  && cmake ${CPLR_CONFIG} ../src \

--- a/README.md
+++ b/README.md
@@ -56,9 +56,17 @@ We build using CMake. You need readline. We bring our own copy of TinyCC.
 ```
 $ git clone https://github.com/promovicz/cplr.git
 $ cd cplr
+$ git submodule init
+$ git submodule update
 $ cmake .
 $ make
 $ make install
+```
+
+Alternatively you can build a docker image containing cplr with
+
+```
+$ docker build -t cplr -f Dockerfile.debian .
 ```
 
 ### Future possibilities


### PR DESCRIPTION
This PR adds some more help for installing and building. Took me a bit to figure out that I had to pull the submodules and to realize that there is already a Dockerfile, so I added that to the README.

If one wants git inside the Docker image or not, depends of personal taste, this is just a suggestion with the idea behind that running a single `docker build` command shall be all one has to do to build the cplr.
I can also change that and state in the README that one has to use `git submodules` first and the build with either Docker or on the host.

PS: thx for the software, it's really fun